### PR TITLE
check if OS is mac and return correct docker command

### DIFF
--- a/commands/start_node.js
+++ b/commands/start_node.js
@@ -11,41 +11,28 @@ const isMacOS = () => {
    }
 }
 
+const callback = (error, stdout, stderr) => {
+   if (error) {
+      if (error.message.includes('permission denied')) {
+         console.log(`Connect: permission denied. Permission issues, try again with sudo`);
+      } else {
+         console.log(`Error: ${error.message}`);
+      }
+      return;
+   }
+   if (stderr) {
+      console.log(`Error: ${stderr}`);
+      return;
+   }
+   console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
+};
+
 const start = async (version) => {
    // Start Node
-   const isMac = isMacOS();
-   if (isMac){
-      exec(`docker run --rm -d --name moonbeam_standalone -p 9944:9944 -p 9933:9933 purestake/moonbeam:${version} --dev --ws-external --rpc-external`, (error, stdout, stderr) => {
-         if (error) {
-            if (error.message.includes('permission denied')) {
-               console.log(`Connect: permission denied. Permission issues, try again with sudo`);
-            } else {
-               console.log(`Error: ${error.message}`);
-            }
-            return;
-         }
-         if (stderr) {
-            console.log(`Error: ${stderr}`);
-            return;
-         }
-         console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
-      });
+   if (isMacOS()){
+      exec(`docker run --rm -d --name moonbeam_standalone -p 9944:9944 -p 9933:9933 purestake/moonbeam:${version} --dev --ws-external --rpc-external`, callback);
    } else {
-      exec(`docker run --rm -d --name moonbeam_standalone --network host purestake/moonbeam:${version} --dev`, (error, stdout, stderr) => {
-         if (error) {
-            if (error.message.includes('permission denied')) {
-               console.log(`Connect: permission denied. Permission issues, try again with sudo`);
-            } else {
-               console.log(`Error: ${error.message}`);
-            }
-            return;
-         }
-         if (stderr) {
-            console.log(`Error: ${stderr}`);
-            return;
-         }
-         console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
-      });
+      exec(`docker run --rm -d --name moonbeam_standalone --network host purestake/moonbeam:${version} --dev`, callback);
    }
 };
 

--- a/commands/start_node.js
+++ b/commands/start_node.js
@@ -1,22 +1,52 @@
 const { exec } = require('child_process');
 
+const isMacOS = () => {
+   // Detect the operating system using process:
+   // https://nodejs.org/api/process.html#process_process_platform
+   const platform = process.platform;
+   if (platform === "darwin") {
+      return true;
+   } else {
+      return false;
+   }
+}
+
 const start = async (version) => {
    // Start Node
-   exec(`docker run --rm -d --name moonbeam_standalone --network host purestake/moonbeam:${version} --dev`, (error, stdout, stderr) => {
-      if (error) {
-         if (error.message.includes('permission denied')) {
-            console.log(`Connect: permission denied. Permission issues, try again with sudo`);
-         } else {
-            console.log(`Error: ${error.message}`);
+   const isMac = isMacOS();
+   if (isMac){
+      exec(`docker run --rm -d --name moonbeam_standalone -p 9944:9944 -p 9933:9933 purestake/moonbeam:${version} --dev --ws-external --rpc-external`, (error, stdout, stderr) => {
+         if (error) {
+            if (error.message.includes('permission denied')) {
+               console.log(`Connect: permission denied. Permission issues, try again with sudo`);
+            } else {
+               console.log(`Error: ${error.message}`);
+            }
+            return;
          }
-         return;
-      }
-      if (stderr) {
-         console.log(`Error: ${stderr}`);
-         return;
-      }
-      console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
-   });
+         if (stderr) {
+            console.log(`Error: ${stderr}`);
+            return;
+         }
+         console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
+      });
+   } else {
+      exec(`docker run --rm -d --name moonbeam_standalone --network host purestake/moonbeam:${version} --dev`, (error, stdout, stderr) => {
+         if (error) {
+            if (error.message.includes('permission denied')) {
+               console.log(`Connect: permission denied. Permission issues, try again with sudo`);
+            } else {
+               console.log(`Error: ${error.message}`);
+            }
+            return;
+         }
+         if (stderr) {
+            console.log(`Error: ${stderr}`);
+            return;
+         }
+         console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
+      });
+   }
 };
 
 module.exports = start;


### PR DESCRIPTION
Use Node's `process.platform` property to determine which operating system the user is on. If the user is on Mac, we modify the docker command to remove `--network "host"`. Then we add the port forwarding `-p 9944:9944 -p 9933:9933` and add these two flags: `--ws-external --rpc-external`.

I checked the other commands, this one seemed to be the only one that needed to be updated.