### PR TITLE
Add ability to start with custom ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ Start the standalone Moonbeam node.
 node_modules/.bin/truffle run moonbeam start
 ```
 
+The start command comes with custom options:
+- `--httpPort`: For setting a custom HTTP port. Accepts a port number to the right of the command.
+- `--wsPort`: For setting a custom WS port. Accepts a port number to the right of the command.
+
+```
+node_modules/.bin/truffle run moonbeam start --httpPort 8545
+```
+
 ## Stop
 Stop the standalone Moonbeam node. This will remove the container, thus purging the chain.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is meant to be used with the Moonbeam Truffle box: https://github.com/PureStake/moonbeam-truffle-box.git
 
-The plugin is used to get you started with a local standalone Moonbeam node quickly. You can check all available commands with the help flag:
+The plugin is used to get you started with a local development Moonbeam node quickly. You can check all available commands with the help flag:
 
 ```
 ./node_modules/.bin/truffle run moonbeam --help
@@ -11,14 +11,14 @@ The plugin is used to get you started with a local standalone Moonbeam node quic
 The following commands are available:
 
 ## Install
-In this context, installing means downloading the Docker image of the Moonbeam standalone node (requires Docker to be installed).
+In this context, installing means downloading the Docker image of the Moonbeam development node (requires Docker to be installed).
 
 ```
 node_modules/.bin/truffle run moonbeam install
 ```
 
 ## Start
-Start the standalone Moonbeam node.
+Start the development Moonbeam node.
 
 ```
 node_modules/.bin/truffle run moonbeam start
@@ -33,35 +33,35 @@ node_modules/.bin/truffle run moonbeam start --rpc-port 8545
 ```
 
 ## Stop
-Stop the standalone Moonbeam node. This will remove the container, thus purging the chain.
+Stop the development Moonbeam node. This will remove the container, thus purging the chain.
 
 ```
 node_modules/.bin/truffle run moonbeam stop
 ```
 
 ## Pause
-Pause the standalone Moonbeam node.
+Pause the development Moonbeam node.
 
 ```
 node_modules/.bin/truffle run moonbeam pause
 ```
 
 ## Unpause
-Unpause the standalone Moonbeam node.
+Unpause the development Moonbeam node.
 
 ```
 node_modules/.bin/truffle run moonbeam unpause
 ```
 
 ## Status
-Shows the status of the standalone Moonbeam node.
+Shows the status of the development Moonbeam node.
 
 ```
 node_modules/.bin/truffle run moonbeam status
 ```
 
 ## Remove
-Removes the Docker image of the Moonbeam standalone node.
+Removes the Docker image of the Moonbeam development node.
 
 ```
 node_modules/.bin/truffle run moonbeam remove

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The start command comes with custom options:
 - `--ws-port`: For setting a custom WS port. Accepts a port number to the right of the command.
 
 ```
-node_modules/.bin/truffle run moonbeam start --httpPort 8545
+node_modules/.bin/truffle run moonbeam start --rpc-port 8545
 ```
 
 ## Stop

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ node_modules/.bin/truffle run moonbeam start
 ```
 
 The start command comes with custom options:
-- `--httpPort`: For setting a custom HTTP port. Accepts a port number to the right of the command.
-- `--wsPort`: For setting a custom WS port. Accepts a port number to the right of the command.
+- `--rpc-port`: For setting a custom HTTP port. Accepts a port number to the right of the command.
+- `--ws-port`: For setting a custom WS port. Accepts a port number to the right of the command.
 
 ```
 node_modules/.bin/truffle run moonbeam start --httpPort 8545

--- a/commands/install_moonbeam.js
+++ b/commands/install_moonbeam.js
@@ -22,7 +22,7 @@ const install = async (version) => {
 }
 
 const get_docker_image = async (version) => {
-   console.log('Downloading Moonbeam Standalone Docker Image...');
+   console.log('Downloading Moonbeam Development Docker Image...');
 
    // Pull Moonbeam Container
    const output = spawn('docker', ['pull', `purestake/moonbeam:${version}`]);

--- a/commands/start_node.js
+++ b/commands/start_node.js
@@ -11,29 +11,45 @@ const isMacOS = () => {
    }
 }
 
-const callback = (error, stdout, stderr) => {
-   if (error) {
-      if (error.message.includes('permission denied')) {
-         console.log(`Connect: permission denied. Permission issues, try again with sudo`);
-      } else {
-         console.log(`Error: ${error.message}`);
+const asyncExec = async (command) => {
+   return new Promise((resolve, reject) => {
+      const callback = (error, stdout, stderr) => {
+         if (error) {
+            if (error.message.includes("permission denied")){
+               reject(`Connect: permission denied. Permission issues, try again with sudo`);
+            } else {
+               reject(`Error: ${error.message}`);
+            }
+         } else if (stderr) {
+            reject(`Error: ${stderr}`);
+         } else {
+            resolve(stdout);
+         }
       }
-      return;
-   }
-   if (stderr) {
-      console.log(`Error: ${stderr}`);
-      return;
-   }
-   console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:9933  WS ws://127.0.0.1:9944 - Container ID ${stdout.substr(0, 12)} \n`);
-};
+      exec(command, callback);
+   })
+}
 
-const start = async (version) => {
+const start = async (version, httpPort, wsPort) => {
+   const publishHttpPort = `-p ${httpPort}:9933`
+   const publishWsPort = `-p ${wsPort}:9944`
+
    // Start Node
-   if (isMacOS()){
-      exec(`docker run --rm -d --name moonbeam_standalone -p 9944:9944 -p 9933:9933 purestake/moonbeam:${version} --dev --ws-external --rpc-external`, callback);
-   } else {
-      exec(`docker run --rm -d --name moonbeam_standalone --network host purestake/moonbeam:${version} --dev`, callback);
+   try {
+      let stdout;
+      if (isMacOS) {
+         // MacOS typically needs to publish the port, so if a user doesn't specify a port let's 
+         // use the defaults 9933 for http and 9944 for ws.
+         stdout = await asyncExec(`docker run --rm -d --name moonbeam_standalone ${httpPort ? publishHttpPort : "-p 9933:9933"} ${wsPort ? publishWsPort : "-p 9944:9944"} purestake/moonbeam:${version} --dev --ws-external --rpc-external`);
+      } else {
+         // If user is not on MacOS, then we only need to publish the port if the user specifies one
+         stdout = await asyncExec(`docker run --rm -d --name moonbeam_standalone --network host ${httpPort || publishHttpPort } ${wsPort || publishWsPort } purestake/moonbeam:${version} --dev`);
+      }
+
+      console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:${httpPort || '9933'}  WS ws://127.0.0.1:${wsPort || '9944'} - Container ID ${stdout.substr(0, 12)} \n`);
+   } catch(e) {
+      console.log(e);
    }
-};
+}
 
 module.exports = start;

--- a/commands/start_node.js
+++ b/commands/start_node.js
@@ -40,10 +40,10 @@ const start = async (version, httpPort, wsPort) => {
       if (isMacOS) {
          // MacOS typically needs to publish the port, so if a user doesn't specify a port let's 
          // use the defaults 9933 for http and 9944 for ws.
-         stdout = await asyncExec(`docker run --rm -d --name moonbeam_standalone ${httpPort ? publishHttpPort : "-p 9933:9933"} ${wsPort ? publishWsPort : "-p 9944:9944"} purestake/moonbeam:${version} --dev --ws-external --rpc-external`);
+         stdout = await asyncExec(`docker run --rm -d --name moonbeam_development ${httpPort ? publishHttpPort : "-p 9933:9933"} ${wsPort ? publishWsPort : "-p 9944:9944"} purestake/moonbeam:${version} --dev --ws-external --rpc-external`);
       } else {
          // If user is not on MacOS, then we only need to publish the port if the user specifies one
-         stdout = await asyncExec(`docker run --rm -d --name moonbeam_standalone --network host ${httpPort || publishHttpPort } ${wsPort || publishWsPort } purestake/moonbeam:${version} --dev`);
+         stdout = await asyncExec(`docker run --rm -d --name moonbeam_development --network host ${httpPort || publishHttpPort } ${wsPort || publishWsPort } purestake/moonbeam:${version} --dev`);
       }
 
       console.log(`Node has started - Endpoints: HTTP http://127.0.0.1:${httpPort || '9933'}  WS ws://127.0.0.1:${wsPort || '9944'} - Container ID ${stdout.substr(0, 12)} \n`);

--- a/moonbeam.js
+++ b/moonbeam.js
@@ -10,7 +10,9 @@ const version = 'tutorial-v6';
 module.exports = (config) => {
    if (config.help) {
       console.log(`Usage: truffle run moonbeam [command]`);
-      console.log(`Commands: install, start, stop, pause, unpause, status, remove`);
+      console.log(`Commands: install, start <start-options>, stop, pause, unpause, status, remove`);
+      console.log(`Start options: --httpPort <custom-port>, --wsPort <custom-port>`);
+      console.log(`For example: truffle run moonbeam start --httpPort 8545`)
       return;
    }
 
@@ -26,7 +28,7 @@ module.exports = (config) => {
          install(version);
          break;
       case 'start':
-         start(version);
+         start(version, config.httpPort, config.wsPort);
          break;
       case 'stop':
          stop(version);

--- a/moonbeam.js
+++ b/moonbeam.js
@@ -11,8 +11,8 @@ module.exports = (config) => {
    if (config.help) {
       console.log(`Usage: truffle run moonbeam [command]`);
       console.log(`Commands: install, start <start-options>, stop, pause, unpause, status, remove`);
-      console.log(`Start options: --httpPort <custom-port>, --wsPort <custom-port>`);
-      console.log(`For example: truffle run moonbeam start --httpPort 8545`)
+      console.log(`Start options: --rpc-port <custom-port>, --ws-port <custom-port>`);
+      console.log(`For example: truffle run moonbeam start --rpc-port 8545`)
       return;
    }
 

--- a/moonbeam.js
+++ b/moonbeam.js
@@ -5,7 +5,7 @@ const pause = require('./commands/pause_node');
 const unpause = require('./commands/unpause_node');
 const status = require('./commands/status_node');
 const remove = require('./commands/remove_moonbeam');
-const version = 'tutorial-v6';
+const version = 'tutorial-v7';
 
 module.exports = (config) => {
    if (config.help) {

--- a/moonbeam.js
+++ b/moonbeam.js
@@ -28,7 +28,7 @@ module.exports = (config) => {
          install(version);
          break;
       case 'start':
-         start(version, config.httpPort, config.wsPort);
+         start(version, config["rpc-port"], config["ws-port"]);
          break;
       case 'stop':
          stop(version);


### PR DESCRIPTION
This PR addresses a feature request from issue #1. It adds the ability to run docker on a custom port for HTTP and WS, by using the options `--rpc-port` and `--ws-port`.

There is an example of usage in the README as well as in the `--help` menu.

✅ Tested on Ubuntu
✅ Tested on MacOS