### PR TITLE
update install command

### DIFF
--- a/commands/install_moonbeam.js
+++ b/commands/install_moonbeam.js
@@ -2,9 +2,10 @@ const { spawn } = require('child_process');
 const axios = require('axios');
 const fs = require('fs');
 
+let version;
+
 // Install function
 const install = async () => {
-  const version = "
   try {
     // Get a list of the releases
     const { data } = await axios.get(

--- a/commands/install_moonbeam.js
+++ b/commands/install_moonbeam.js
@@ -2,13 +2,25 @@ const { spawn } = require('child_process');
 const axios = require('axios');
 const fs = require('fs');
 
-let version;
-
 // Install function
 const install = async () => {
+  const version = "
   try {
-    const { data } = await axios.get('https://api.github.com/repos/purestake/moonbeam/releases/latest');
-    version = data.tag_name;
+    // Get a list of the releases
+    const { data } = await axios.get(
+      "https://api.github.com/repos/purestake/moonbeam/releases"
+    );
+    for (var i = 0; i < data.length; i++) {
+      // Get the list of assets per release
+      const assets = data[i].assets;
+      // Filter the assets for the moonbeam asset (if it exists)
+      const moonbeamAsset = assets.filter((asset) => asset.name === "moonbeam");
+      // If the moonbeam asset exists, save the version and break out of the loop
+      if (moonbeamAsset.length > 0) {
+        version = data[i].tag_name;
+        break;
+      }
+    }
   } catch (err) {
     // Handle Error Here
     console.error(err);


### PR DESCRIPTION
When installing the latest docker image, it was trying to install `runtime-2100`, initially considered just setting `version = 'latest'` however, I feel this is a better solution as it logs the version number that was installed instead of `latest`

tested this out by patching the package in the moonbeam-truffle-box and all works as expected