### PR TITLE
update help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,18 @@
 
 This is meant to be used with the Moonbeam Truffle box: https://github.com/PureStake/moonbeam-truffle-box.git
 
+You can run any of the commands below from within the Moonbeam Truffle Box repo.
+
 The plugin is used to get you started with a local development Moonbeam node quickly. You can check all available commands with the help flag:
 
 ```
-./node_modules/.bin/truffle run moonbeam --help
+./node_modules/.bin/truffle run moonbeam help
 ```
 
 The following commands are available:
 
 ## Install
+
 In this context, installing means downloading the Docker image of the Moonbeam development node (requires Docker to be installed).
 
 ```
@@ -18,6 +21,7 @@ node_modules/.bin/truffle run moonbeam install
 ```
 
 ## Start
+
 Start the development Moonbeam node.
 
 ```
@@ -32,6 +36,7 @@ node_modules/.bin/truffle run moonbeam start --ws-port 8545
 ```
 
 ## Stop
+
 Stop the development Moonbeam node. This will remove the container, thus purging the chain.
 
 ```
@@ -39,6 +44,7 @@ node_modules/.bin/truffle run moonbeam stop
 ```
 
 ## Pause
+
 Pause the development Moonbeam node.
 
 ```
@@ -46,6 +52,7 @@ node_modules/.bin/truffle run moonbeam pause
 ```
 
 ## Unpause
+
 Unpause the development Moonbeam node.
 
 ```
@@ -53,6 +60,7 @@ node_modules/.bin/truffle run moonbeam unpause
 ```
 
 ## Status
+
 Shows the status of the development Moonbeam node.
 
 ```
@@ -60,6 +68,7 @@ node_modules/.bin/truffle run moonbeam status
 ```
 
 ## Remove
+
 Removes the Docker image of the Moonbeam development node.
 
 ```
@@ -67,4 +76,5 @@ node_modules/.bin/truffle run moonbeam remove
 ```
 
 # Contact Us
+
 We welcome any feedback, so feel free to reach out through our official [Discord Channel](https://discord.gg/PfpUATX).

--- a/commands/install_moonbeam.js
+++ b/commands/install_moonbeam.js
@@ -8,7 +8,7 @@ let version;
 const install = async () => {
   try {
     const { data } = await axios.get('https://api.github.com/repos/purestake/moonbeam/releases/latest');
-    version = 'v0.32.1';
+    version = data.tag_name;
   } catch (err) {
     // Handle Error Here
     console.error(err);

--- a/commands/install_moonbeam.js
+++ b/commands/install_moonbeam.js
@@ -8,7 +8,7 @@ let version;
 const install = async () => {
   try {
     const { data } = await axios.get('https://api.github.com/repos/purestake/moonbeam/releases/latest');
-    version = data.tag_name;
+    version = 'v0.32.1';
   } catch (err) {
     // Handle Error Here
     console.error(err);

--- a/moonbeam.js
+++ b/moonbeam.js
@@ -7,7 +7,7 @@ const status = require('./commands/status_node');
 const remove = require('./commands/remove_moonbeam');
 
 module.exports = (config) => {
-  if (config.help) {
+  if (config._[1] == 'help') {
     console.log(`Usage: truffle run moonbeam [command]`);
     console.log(`Commands: install, start <start-options>, stop, pause, unpause, status, remove`);
     console.log(`Start options: --ws-port <custom-port>`);
@@ -16,7 +16,7 @@ module.exports = (config) => {
   }
 
   if (config._.length < 2) {
-    console.log('No command provided. Run truffle run moonbeam --help to see the full list.');
+    console.log('No command provided. Run truffle run moonbeam help to see the full list.');
     return;
   }
 
@@ -43,6 +43,6 @@ module.exports = (config) => {
       remove();
       break;
     default:
-      console.log('Command not found. Run truffle run moonbeam --help to see the full list.');
+      console.log('Command not found. Run truffle run moonbeam help to see the full list.');
   }
 };


### PR DESCRIPTION
This PR updates the help flag. I'm not sure how this previously worked, i'm used to using something like yargs or process.argv but this never seemed to do either. So I just updated it quickly to use `help` instead of `--help` (like the other commands) and updated the readme as well